### PR TITLE
Add suggestion to include in development/test group

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Here's an example application package dependency diagram:
 
 Add this line to your application's Gemfile and run `bundle install`:
 
-`gem 'graphwerk'`
+`gem 'graphwerk', group: %i[development test]`
 
 ## Usage
 


### PR DESCRIPTION
This PR adds a suggestion to include `gem 'graphwerk'` only in the `development` and `test` groups of an applications Gemfile since it isn't used at runtime in production so there's little point in it being loaded.

This reflects our usage of the gem within https://github.com/tricycle/ applications but I figured I'd make it nice and obvious to anyone bumping into the gem.