### PR TITLE
Fix issue in node name that occurs when dependency relies on root package

### DIFF
--- a/spec/lib/graphwerk/builders/graph_spec.rb
+++ b/spec/lib/graphwerk/builders/graph_spec.rb
@@ -69,6 +69,39 @@ module Graphwerk
             }
           DOT
         end
+
+        context 'when a package depends on the root' do
+          let(:frontend_package) do
+            Packwerk::Package.new(
+              name: 'components/frontend',
+              config: {
+                'dependencies' => ['components/images', '.']
+              }
+            )
+          end
+
+          specify do
+            expect(diagram).to eq <<~DOT
+              digraph "strict" {
+              Application [style = "filled", fillcolor = "#333333", fontcolor = "white", label = "Application", color = "black"];
+              root = "Application";
+              overlap = "false";
+              splines = "true";
+              node[ shape  =  "box" , style  =  "rounded, filled" , fontcolor  =  "white" , fillcolor  =  "#EF673E" , color  =  "#EF673E" , fontname  =  "Lato"];
+              edge[ len  =  "0.4"];
+              "storage_providers/s3" [color = "azure4", label = "storage_providers/s3"];
+              frontend [color = "azure4", label = "frontend"];
+              images [color = "azure4", label = "images"];
+              admin [color = "azure4", label = "admin"];
+                frontend -> images [color = "azure4"];
+                frontend -> Application [color = "azure4"];
+                images -> "storage_providers/s3" [color = "azure4"];
+                Application -> frontend [color = "black"];
+                Application -> admin [color = "black"];
+              }
+            DOT
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes #1 by extracting the package name to node name logic and applying it correctly to both the package node and the dependency node connections.