### PR TITLE
Switch default layout engine to Dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The gem builds on top of [Packwerk](https://github.com/Shopify/packwerk) and [Gr
 
 Here's an example application package dependency diagram:
 
-![example](https://user-images.githubusercontent.com/2643026/95458900-c159c000-096a-11eb-86b7-b5ef7c1e936d.png)
+![example](https://user-images.githubusercontent.com/2643026/97689408-6ca1f480-1a93-11eb-9999-22e79791b300.png)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For Rails applications a Railtie automatically loads a rake task that makes it e
 bundle exec rake graphwerk:update
 ```
 
-More advance usage is possible by passing a `Packwerk::PackageSet` directly to `Graphwerk::Builders::Graph` and calling `#build` returning a `Graphviz` instance:
+More advance usage is possible by passing a [`Packwerk::PackageSet`](https://github.com/Shopify/packwerk/blob/main/lib/packwerk/package_set.rb) directly to `Graphwerk::Builders::Graph` and calling `#build` returning a `Graphviz` instance:
 
 ```ruby
 graph = Graphwerk::Builders::Graph.new(
@@ -33,7 +33,7 @@ graph = Graphwerk::Builders::Graph.new(
 graph.output(svg: 'packwerk.svg')
 ```
 
-All Graphviz layouts are supported and options for the graph, nodes and edges can be set via an optional `options` argument:
+All [Graphviz layouts](https://graphviz.org/documentation/#layout-manual-pages) are supported and options for the graph, nodes and edges can be set via an optional `options` argument:
 
 ```ruby
 graph = Graphwerk::Builders::Graph.new(

--- a/lib/graphwerk/builders/graph.rb
+++ b/lib/graphwerk/builders/graph.rb
@@ -17,7 +17,7 @@ module Graphwerk
       }
 
       DEFAULT_OPTIONS = T.let({
-        layout: Graphwerk::Layout::Fdp,
+        layout: Graphwerk::Layout::Dot,
         application: {
           style: 'filled',
           fillcolor: '#333333',

--- a/lib/graphwerk/layout.rb
+++ b/lib/graphwerk/layout.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 module Graphwerk
+  # https://graphviz.org/documentation/#layout-manual-pages
   class Layout < T::Enum
     enums do
       Dot = new


### PR DESCRIPTION
This PR switches the default layout engine to Dot helping produce dependency graphs that better show the (hopefully, dependent on your architecture!) acyclic nature of your dependencies with arrows that point in a single downwards direction.

Diagrams will now look something like this:

![image](https://user-images.githubusercontent.com/2643026/97690726-48471780-1a95-11eb-8a00-a57efc96e895.png)

Or this example from an [in-house](https://github.com/tricycle) application (👀  spot the circular dependency!):
![packwerk](https://user-images.githubusercontent.com/2643026/97691252-09fe2800-1a96-11eb-8573-38a11ae9b426.jpg)

This PR also adds additional documentation around how to choose a different layout engine.


