### PR TITLE
Draw deprecated references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+
+* Deprecated references are now drawn on the output graph.
+
 1.1.0
 
 * Default layout switched to Dot

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ graph = Graphwerk::Builders::Graph.new(
    Packwerk::PackageSet.load_all_from("."),
    options: {
      layout: Graphwerk::Layout::Twopi,
+     deprecated_references_color: 'yellow',
      graph: { overlap: true },
      node: { fillcolor: '#000000' },
      edges: { len: '3.0' }

--- a/lib/graphwerk.rb
+++ b/lib/graphwerk.rb
@@ -8,6 +8,7 @@ require 'active_support/core_ext/hash/deep_merge'
 require 'graphwerk/version'
 require 'graphwerk/constants'
 require 'graphwerk/layout'
+require 'graphwerk/deprecated_references_loader'
 require 'graphwerk/presenters/package'
 require 'graphwerk/builders/graph'
 require 'graphwerk/railtie' if defined?(Rails)

--- a/lib/graphwerk/builders/graph.rb
+++ b/lib/graphwerk/builders/graph.rb
@@ -41,10 +41,11 @@ module Graphwerk
         }
       }, OptionsShape)
 
-      sig { params(package_set: Packwerk::PackageSet, options: T::Hash[Symbol, Object]).void }
-      def initialize(package_set, options: {})
+      sig { params(package_set: Packwerk::PackageSet, options: T::Hash[Symbol, Object], root_path: Pathname).void }
+      def initialize(package_set, options: {}, root_path: Pathname.new(ENV['PWD']))
         @package_set = package_set
         @options = T.let(DEFAULT_OPTIONS.deep_merge(options), OptionsShape)
+        @root_path = root_path
         @graph = T.let(build_empty_graph, GraphViz)
         @nodes = T.let(build_empty_nodes, T::Hash[String, GraphViz::Node])
       end
@@ -105,7 +106,7 @@ module Graphwerk
       sig { returns(T::Array[Presenters::Package]) }
       def packages
         @packages = T.let(@packages, T.nilable(T::Array[Presenters::Package]))
-        @packages ||= @package_set.map { |package| Presenters::Package.new(package) }
+        @packages ||= @package_set.map { |package| Presenters::Package.new(package, @root_path) }
       end
     end
   end

--- a/lib/graphwerk/builders/graph.rb
+++ b/lib/graphwerk/builders/graph.rb
@@ -9,6 +9,7 @@ module Graphwerk
       OptionsShape = T.type_alias {
         {
           layout: Graphwerk::Layout,
+          deprecated_references_color: String,
           application: T::Hash[Symbol, Object],
           graph: T::Hash[Symbol, Object],
           node: T::Hash[Symbol, Object],
@@ -18,6 +19,7 @@ module Graphwerk
 
       DEFAULT_OPTIONS = T.let({
         layout: Graphwerk::Layout::Dot,
+        deprecated_references_color: 'red',
         application: {
           style: 'filled',
           fillcolor: '#333333',
@@ -86,7 +88,10 @@ module Graphwerk
 
       sig { void }
       def add_package_dependencies_to_graph
-        packages.each { |package| draw_dependencies(package) }
+        packages.each do |package|
+          draw_dependencies(package)
+          draw_deprecated_references(package)
+        end
       end
 
       sig { void }
@@ -100,6 +105,17 @@ module Graphwerk
       def draw_dependencies(package)
         package.dependencies.each do |dependency|
           @graph.add_edges(@nodes[package.name], @nodes[dependency], color: package.color)
+        end
+      end
+
+      sig { params(package: Presenters::Package).void }
+      def draw_deprecated_references(package)
+        package.deprecated_references.each do |reference|
+          @graph.add_edges(
+            @nodes[package.name],
+            @nodes[reference],
+            color: @options[:deprecated_references_color]
+          )
         end
       end
 

--- a/lib/graphwerk/deprecated_references_loader.rb
+++ b/lib/graphwerk/deprecated_references_loader.rb
@@ -1,0 +1,31 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Graphwerk
+  class DeprecatedReferencesLoader
+    extend T::Sig
+
+    sig { params(package: Packwerk::Package, root_path: Pathname).void }
+    def initialize(package, root_path)
+      @package = package
+      @root_path = root_path
+    end
+
+    sig { returns(T::Array[String]) }
+    def load
+      return [] if !deprecated_references_file.exist?
+
+      (YAML.load_file(deprecated_references_file) || {}).keys
+    end
+
+    private
+
+    DEPRECATED_REFERENCES_FILENAME = 'deprecated_references.yml'
+
+    sig { returns(Pathname) }
+    def deprecated_references_file
+      @deprecated_references_file = T.let(@deprecated_references_file, T.nilable(Pathname))
+      @deprecated_references_file ||= @root_path.join(@package.name, DEPRECATED_REFERENCES_FILENAME)
+    end
+  end
+end

--- a/lib/graphwerk/presenters/package.rb
+++ b/lib/graphwerk/presenters/package.rb
@@ -54,11 +54,9 @@ module Graphwerk
           Constants::ROOT_PACKAGE_NAME
         end
 
-        ROOT_PACKAGE = '.'
-
         sig { returns(T::Boolean) }
         def root?
-          @package_name == ROOT_PACKAGE
+          @package_name == Packwerk::Package::ROOT_PACKAGE_NAME
         end
 
         private
@@ -67,8 +65,6 @@ module Graphwerk
         def without_root_package
           T.must(@package_name.split('/', 2).last)
         end
-
-        private_constant :ROOT_PACKAGE
       end
 
       private_constant :ROOT_COLOR,

--- a/lib/graphwerk/presenters/package.rb
+++ b/lib/graphwerk/presenters/package.rb
@@ -24,9 +24,7 @@ module Graphwerk
 
       sig { returns(T::Array[String]) }
       def deprecated_references
-        return [] if !deprecated_references_file.exist?
-
-        (YAML.load_file(deprecated_references_file) || {}).keys.map do |reference|
+        DeprecatedReferencesLoader.new(@package, @root_path).load.map do |reference|
           Name.new(reference).node_name
         end
       end
@@ -42,14 +40,6 @@ module Graphwerk
       end
 
       private
-
-      DEPRECATED_REFERENCES_FILENAME = 'deprecated_references.yml'
-
-      sig { returns(Pathname) }
-      def deprecated_references_file
-        @deprecated_references_file = T.let(@deprecated_references_file, T.nilable(Pathname))
-        @deprecated_references_file ||= @root_path.join(@package.name, DEPRECATED_REFERENCES_FILENAME)
-      end
 
       sig { returns(Name) }
       def package_name

--- a/spec/lib/graphwerk/builders/graph_spec.rb
+++ b/spec/lib/graphwerk/builders/graph_spec.rb
@@ -49,6 +49,18 @@ module Graphwerk
       describe '#build' do
         subject(:diagram) { builder.build.to_s }
 
+        let(:deprecated_references_loader_for_images) do
+          instance_double(DeprecatedReferencesLoader, load: ['.'])
+        end
+
+        before do
+          allow(DeprecatedReferencesLoader).to receive(:new).and_call_original
+          expect(DeprecatedReferencesLoader)
+            .to receive(:new)
+            .with(images_package, an_instance_of(Pathname))
+            .and_return(deprecated_references_loader_for_images)
+        end
+
         specify do
           expect(diagram).to eq <<~DOT
             digraph "strict" {
@@ -64,6 +76,7 @@ module Graphwerk
             admin [color = "azure4", label = "admin"];
               frontend -> images [color = "azure4"];
               images -> "storage_providers/s3" [color = "azure4"];
+              images -> Application [color = "red"];
               Application -> frontend [color = "black"];
               Application -> admin [color = "black"];
             }
@@ -96,6 +109,7 @@ module Graphwerk
                 frontend -> images [color = "azure4"];
                 frontend -> Application [color = "azure4"];
                 images -> "storage_providers/s3" [color = "azure4"];
+                images -> Application [color = "red"];
                 Application -> frontend [color = "black"];
                 Application -> admin [color = "black"];
               }

--- a/spec/lib/graphwerk/deprecated_references_loader_spec.rb
+++ b/spec/lib/graphwerk/deprecated_references_loader_spec.rb
@@ -1,0 +1,58 @@
+# typed: false
+# frozen_string_literal: true
+
+module Graphwerk
+  describe DeprecatedReferencesLoader do
+    let(:service) { described_class.new(package, root_path) }
+
+    let(:package) do
+      Packwerk::Package.new(
+        name: 'components/admin',
+        config: { 'dependencies' => ['components/security', 'components/orders'] }
+      )
+    end
+    let(:root_path) { Pathname.new('.') }
+
+    describe '#load' do
+      subject { service.load }
+
+      let(:deprecated_references_file) { instance_double(Pathname) }
+
+      before do
+        expect(root_path)
+          .to receive(:join)
+          .with('components/admin', 'deprecated_references.yml')
+          .and_return(deprecated_references_file)
+        expect(deprecated_references_file)
+          .to receive(:exist?)
+          .and_return(deprecated_dependency_file_is_present)
+      end
+
+      context 'when no deprecated dependency file is present' do
+        let(:deprecated_dependency_file_is_present) { false }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'when a deprecated dependency file is present' do
+        let(:deprecated_dependency_file_is_present) { true }
+
+        before do
+          expect(YAML)
+            .to receive(:load_file)
+            .with(deprecated_references_file)
+            .and_return(
+              '.' => {
+                "::Order" => {
+                  "violations" => ["dependency"],
+                  "files" => ["components/admin/interfaces/gateway.rb"]
+                }
+              }
+            )
+        end
+
+        it { is_expected.to contain_exactly('.') }
+      end
+    end
+  end
+end

--- a/spec/lib/graphwerk/presenters/package_spec.rb
+++ b/spec/lib/graphwerk/presenters/package_spec.rb
@@ -47,43 +47,17 @@ module Graphwerk
       describe '#deprecated_references' do
         subject { presenter.deprecated_references }
 
-        let(:deprecated_references_file) { instance_double(Pathname) }
+        let(:deprecated_references_loader) { instance_double(DeprecatedReferencesLoader) }
 
         before do
-          expect(root_path)
-            .to receive(:join)
-            .with('components/admin', 'deprecated_references.yml')
-            .and_return(deprecated_references_file)
-          expect(deprecated_references_file)
-            .to receive(:exist?)
-            .and_return(deprecated_dependency_file_is_present)
+          expect(DeprecatedReferencesLoader)
+            .to receive(:new)
+            .with(package, root_path)
+            .and_return(deprecated_references_loader)
+          expect(deprecated_references_loader).to receive(:load).and_return(['.'])
         end
 
-        context 'when no deprecated dependency file is present' do
-          let(:deprecated_dependency_file_is_present) { false }
-
-          it { is_expected.to be_empty }
-        end
-
-        context 'when a deprecated dependency file is present' do
-          let(:deprecated_dependency_file_is_present) { true }
-
-          before do
-            expect(YAML)
-              .to receive(:load_file)
-              .with(deprecated_references_file)
-              .and_return(
-                '.' => {
-                  "::Order" => {
-                    "violations" => ["dependency"],
-                    "files" => ["components/admin/interfaces/gateway.rb"]
-                  }
-                }
-              )
-          end
-
-          it { is_expected.to contain_exactly('Application') }
-        end
+        it { is_expected.to contain_exactly('Application') }
       end
 
       describe '#color' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'
 
   RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+  RSpec::Sorbet.allow_doubles!
   # Disable RSpec exposing methods globally on `Module` and `main`
   # config.disable_monkey_patching!
 


### PR DESCRIPTION
This PR implements an idea raised in #6 where it was suggested that drawing deprecated references would be useful in helping reveal issues in an application's architecture.

![image](https://user-images.githubusercontent.com/2643026/101684074-bc45e980-3a5d-11eb-8801-079e30f2f1dd.png)

Red arrows now indicate a deprecated reference from one package to another, in the above example our images component is referencing a class in the Application.