### PR TITLE
Abort with descriptive error if dependency not found

### DIFF
--- a/lib/graphwerk/builders/graph.rb
+++ b/lib/graphwerk/builders/graph.rb
@@ -104,6 +104,9 @@ module Graphwerk
       sig { params(package: Presenters::Package).void }
       def draw_dependencies(package)
         package.dependencies.each do |dependency|
+          unless @nodes[dependency]
+            abort "Unable to add edge `#{package.name}`->`#{dependency}`"
+          end
           @graph.add_edges(@nodes[package.name], @nodes[dependency], color: package.color)
         end
       end


### PR DESCRIPTION
Hello!

Every now and then I typo a package name in a dependency list and graphwerk fails to generate a rendering of our dependency graph with the following error coming from `GraphViz#add_edges`:

```
NoMethodError: undefined method `id' for nil:NilClass
```

This makes it really hard for me to find the problem. I know I could run `packwerk validate` to find the issue, but it's another thing to boot up and run and it can be slow while in the iteration cycle. We already have all of the information here to provide a clearer error message, so I think it would make sense to proactively handle this case inline.

Would you all be interested in adding a more helpful error message here?

Thanks!