### PR TITLE
Draw package_todo.yml dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+
+* Draw package_todo.yml dependencies
+
 1.2.1
 
 * Add some nicer error messages when dependencies are not found

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ graph = Graphwerk::Builders::Graph.new(
    options: {
      layout: Graphwerk::Layout::Twopi,
      deprecated_references_color: 'yellow',
+     package_todo_color: 'yellow',
      graph: { overlap: true },
      node: { fillcolor: '#000000' },
      edges: { len: '3.0' }

--- a/lib/graphwerk.rb
+++ b/lib/graphwerk.rb
@@ -9,6 +9,7 @@ require 'graphwerk/version'
 require 'graphwerk/constants'
 require 'graphwerk/layout'
 require 'graphwerk/deprecated_references_loader'
+require 'graphwerk/package_todo_loader'
 require 'graphwerk/presenters/package'
 require 'graphwerk/builders/graph'
 require 'graphwerk/railtie' if defined?(Rails)

--- a/lib/graphwerk/builders/graph.rb
+++ b/lib/graphwerk/builders/graph.rb
@@ -10,6 +10,7 @@ module Graphwerk
         {
           layout: Graphwerk::Layout,
           deprecated_references_color: String,
+          package_todo_color: String,
           application: T::Hash[Symbol, Object],
           graph: T::Hash[Symbol, Object],
           node: T::Hash[Symbol, Object],
@@ -20,6 +21,7 @@ module Graphwerk
       DEFAULT_OPTIONS = T.let({
         layout: Graphwerk::Layout::Dot,
         deprecated_references_color: 'red',
+        package_todo_color: 'red',
         application: {
           style: 'filled',
           fillcolor: '#333333',
@@ -91,6 +93,7 @@ module Graphwerk
         packages.each do |package|
           draw_dependencies(package)
           draw_deprecated_references(package)
+          draw_package_todos(package)
         end
       end
 
@@ -118,6 +121,17 @@ module Graphwerk
             @nodes[package.name],
             @nodes[reference],
             color: @options[:deprecated_references_color]
+          )
+        end
+      end
+
+      sig { params(package: Presenters::Package).void }
+      def draw_package_todos(package)
+        package.package_todos.each do |todo|
+          @graph.add_edges(
+            @nodes[package.name],
+            @nodes[todo],
+            color: @options[:package_todo_color]
           )
         end
       end

--- a/lib/graphwerk/package_todo_loader.rb
+++ b/lib/graphwerk/package_todo_loader.rb
@@ -1,0 +1,31 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Graphwerk
+  class PackageTodoLoader
+    extend T::Sig
+
+    sig { params(package: Packwerk::Package, root_path: Pathname).void }
+    def initialize(package, root_path)
+      @package = package
+      @root_path = root_path
+    end
+
+    sig { returns(T::Array[String]) }
+    def load
+      return [] if !package_todo_file.exist?
+
+      (YAML.load_file(package_todo_file) || {}).keys
+    end
+
+    private
+
+    PACKAGE_TODO_FILENAME = 'package_todo.yml'
+
+    sig { returns(Pathname) }
+    def package_todo_file
+      @package_todo_file = T.let(@package_todo_file, T.nilable(Pathname))
+      @package_todo_file ||= @root_path.join(@package.name, PACKAGE_TODO_FILENAME)
+    end
+  end
+end

--- a/lib/graphwerk/presenters/package.rb
+++ b/lib/graphwerk/presenters/package.rb
@@ -29,6 +29,13 @@ module Graphwerk
         end
       end
 
+      sig { returns(T::Array[String]) }
+      def package_todos
+        PackageTodoLoader.new(@package, @root_path).load.map do |todo|
+          Name.new(todo).node_name
+        end
+      end
+
       ROOT_COLOR = 'black'
       COMPONENT_COLOR = 'azure4'
 

--- a/spec/lib/graphwerk/builders/graph_spec.rb
+++ b/spec/lib/graphwerk/builders/graph_spec.rb
@@ -53,12 +53,21 @@ module Graphwerk
           instance_double(DeprecatedReferencesLoader, load: ['.'])
         end
 
+        let(:package_todo_loader_for_frontend) do
+          instance_double(PackageTodoLoader, load: ['components/storage_providers/s3'])
+        end
+
         before do
           allow(DeprecatedReferencesLoader).to receive(:new).and_call_original
           expect(DeprecatedReferencesLoader)
             .to receive(:new)
             .with(images_package, an_instance_of(Pathname))
             .and_return(deprecated_references_loader_for_images)
+          allow(PackageTodoLoader).to receive(:new).and_call_original
+          expect(PackageTodoLoader)
+            .to receive(:new)
+            .with(frontend_package, an_instance_of(Pathname))
+            .and_return(package_todo_loader_for_frontend)
         end
 
         specify do
@@ -75,6 +84,7 @@ module Graphwerk
             images [color = "azure4", label = "images"];
             admin [color = "azure4", label = "admin"];
               frontend -> images [color = "azure4"];
+              frontend -> "storage_providers/s3" [color = "red"];
               images -> "storage_providers/s3" [color = "azure4"];
               images -> Application [color = "red"];
               Application -> frontend [color = "black"];
@@ -108,6 +118,7 @@ module Graphwerk
               admin [color = "azure4", label = "admin"];
                 frontend -> images [color = "azure4"];
                 frontend -> Application [color = "azure4"];
+                frontend -> "storage_providers/s3" [color = "red"];
                 images -> "storage_providers/s3" [color = "azure4"];
                 images -> Application [color = "red"];
                 Application -> frontend [color = "black"];

--- a/spec/lib/graphwerk/package_todo_loader_spec.rb
+++ b/spec/lib/graphwerk/package_todo_loader_spec.rb
@@ -1,0 +1,58 @@
+# typed: false
+# frozen_string_literal: true
+
+module Graphwerk
+  describe PackageTodoLoader do
+    let(:service) { described_class.new(package, root_path) }
+
+    let(:package) do
+      Packwerk::Package.new(
+        name: 'components/admin',
+        config: { 'dependencies' => ['components/security', 'components/orders'] }
+      )
+    end
+    let(:root_path) { Pathname.new('.') }
+
+    describe '#load' do
+      subject { service.load }
+
+      let(:package_todo_file) { instance_double(Pathname) }
+
+      before do
+        expect(root_path)
+          .to receive(:join)
+                .with('components/admin', 'package_todo.yml')
+                .and_return(package_todo_file)
+        expect(package_todo_file)
+          .to receive(:exist?)
+                .and_return(package_todo_file_is_present)
+      end
+
+      context 'when no deprecated dependency file is present' do
+        let(:package_todo_file_is_present) { false }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'when a deprecated dependency file is present' do
+        let(:package_todo_file_is_present) { true }
+
+        before do
+          expect(YAML)
+            .to receive(:load_file)
+                  .with(package_todo_file)
+                  .and_return(
+                    '.' => {
+                      "::Order" => {
+                        "violations" => ["dependency"],
+                        "files" => ["components/admin/interfaces/gateway.rb"]
+                      }
+                    }
+                  )
+        end
+
+        it { is_expected.to contain_exactly('.') }
+      end
+    end
+  end
+end

--- a/spec/lib/graphwerk/presenters/package_spec.rb
+++ b/spec/lib/graphwerk/presenters/package_spec.rb
@@ -60,6 +60,22 @@ module Graphwerk
         it { is_expected.to contain_exactly('Application') }
       end
 
+      describe '#package_todos' do
+        subject { presenter.package_todos }
+
+        let(:package_todo_loader) { instance_double(PackageTodoLoader) }
+
+        before do
+          expect(PackageTodoLoader)
+            .to receive(:new)
+                  .with(package, root_path)
+                  .and_return(package_todo_loader)
+          expect(package_todo_loader).to receive(:load).and_return(['.'])
+        end
+
+        it { is_expected.to contain_exactly('Application') }
+      end
+
       describe '#color' do
         subject { presenter.color }
 


### PR DESCRIPTION
A change was made at https://github.com/samuelgiles/graphwerk/pull/7 to draw deprecated dependencies, now named `package_todo.yml` instead of `deprecated_references.yml`.

I thought about renaming `DeprecatedReferencesLoader`, but if people are still using the old packwerk, it would be a breaking change, so I added the `PackageTodoLoader` instead of renaming it.