### PR TITLE
Add configuration option to hide todo edges on the graph

### DIFF
--- a/lib/graphwerk/builders/graph.rb
+++ b/lib/graphwerk/builders/graph.rb
@@ -11,6 +11,7 @@ module Graphwerk
           layout: Graphwerk::Layout,
           deprecated_references_color: String,
           package_todo_color: String,
+          hide_todo: T::Boolean,
           application: T::Hash[Symbol, Object],
           graph: T::Hash[Symbol, Object],
           node: T::Hash[Symbol, Object],
@@ -22,6 +23,7 @@ module Graphwerk
         layout: Graphwerk::Layout::Dot,
         deprecated_references_color: 'red',
         package_todo_color: 'red',
+        hide_todo: false,
         application: {
           style: 'filled',
           fillcolor: '#333333',
@@ -92,6 +94,8 @@ module Graphwerk
       def add_package_dependencies_to_graph
         packages.each do |package|
           draw_dependencies(package)
+          next if @options[:hide_todo]
+
           draw_deprecated_references(package)
           draw_package_todos(package)
         end

--- a/spec/lib/graphwerk/builders/graph_spec.rb
+++ b/spec/lib/graphwerk/builders/graph_spec.rb
@@ -59,12 +59,12 @@ module Graphwerk
 
         before do
           allow(DeprecatedReferencesLoader).to receive(:new).and_call_original
-          expect(DeprecatedReferencesLoader)
+          allow(DeprecatedReferencesLoader)
             .to receive(:new)
             .with(images_package, an_instance_of(Pathname))
             .and_return(deprecated_references_loader_for_images)
           allow(PackageTodoLoader).to receive(:new).and_call_original
-          expect(PackageTodoLoader)
+          allow(PackageTodoLoader)
             .to receive(:new)
             .with(frontend_package, an_instance_of(Pathname))
             .and_return(package_todo_loader_for_frontend)
@@ -125,6 +125,31 @@ module Graphwerk
                 Application -> admin [color = "black"];
               }
             DOT
+          end
+        end
+
+        context 'when hiding todos' do
+          let(:builder) { described_class.new(package_set, options: { hide_todo: true }) }
+
+          specify do
+            expect(diagram).to eq <<~DOT
+            digraph "strict" {
+            Application [style = "filled", fillcolor = "#333333", fontcolor = "white", label = "Application", color = "black"];
+            root = "Application";
+            overlap = "false";
+            splines = "true";
+            node[ shape  =  "box" , style  =  "rounded, filled" , fontcolor  =  "white" , fillcolor  =  "#EF673E" , color  =  "#EF673E" , fontname  =  "Lato"];
+            edge[ len  =  "0.4"];
+            "storage_providers/s3" [color = "azure4", label = "storage_providers/s3"];
+            frontend [color = "azure4", label = "frontend"];
+            images [color = "azure4", label = "images"];
+            admin [color = "azure4", label = "admin"];
+              frontend -> images [color = "azure4"];
+              images -> "storage_providers/s3" [color = "azure4"];
+              Application -> frontend [color = "black"];
+              Application -> admin [color = "black"];
+            }
+          DOT
           end
         end
       end


### PR DESCRIPTION
I like the ability to draw the todo violations however in some cases I want to be able to see a clean dependency graph as well. This PR adds a configuration option to hide the todo edges. By default it will show them to keep existing behaviour the same.

Related pull requests:
- https://github.com/samuelgiles/graphwerk/pull/7
- https://github.com/samuelgiles/graphwerk/pull/12