### PR TITLE
Replace YAML.load_file with YAML.safe_load_file for security

### DIFF
--- a/lib/graphwerk/deprecated_references_loader.rb
+++ b/lib/graphwerk/deprecated_references_loader.rb
@@ -15,7 +15,7 @@ module Graphwerk
     def load
       return [] if !deprecated_references_file.exist?
 
-      (YAML.load_file(deprecated_references_file) || {}).keys
+      (YAML.safe_load_file(deprecated_references_file) || {}).keys
     end
 
     private

--- a/lib/graphwerk/package_todo_loader.rb
+++ b/lib/graphwerk/package_todo_loader.rb
@@ -15,7 +15,7 @@ module Graphwerk
     def load
       return [] if !package_todo_file.exist?
 
-      (YAML.load_file(package_todo_file) || {}).keys
+      (YAML.safe_load_file(package_todo_file) || {}).keys
     end
 
     private

--- a/spec/lib/graphwerk/deprecated_references_loader_spec.rb
+++ b/spec/lib/graphwerk/deprecated_references_loader_spec.rb
@@ -53,6 +53,15 @@ module Graphwerk
 
         it { is_expected.to contain_exactly('.') }
       end
+
+    end
+
+    describe '#load with a real YAML fixture file' do
+      let(:root_path) { Pathname.new(File.expand_path('../../support/fixtures', __dir__)) }
+
+      it 'parses the file with safe_load_file and returns the keys' do
+        expect(service.load).to contain_exactly('.', 'components/shipping')
+      end
     end
   end
 end

--- a/spec/lib/graphwerk/deprecated_references_loader_spec.rb
+++ b/spec/lib/graphwerk/deprecated_references_loader_spec.rb
@@ -39,7 +39,7 @@ module Graphwerk
 
         before do
           expect(YAML)
-            .to receive(:load_file)
+            .to receive(:safe_load_file)
             .with(deprecated_references_file)
             .and_return(
               '.' => {

--- a/spec/lib/graphwerk/package_todo_loader_spec.rb
+++ b/spec/lib/graphwerk/package_todo_loader_spec.rb
@@ -39,7 +39,7 @@ module Graphwerk
 
         before do
           expect(YAML)
-            .to receive(:load_file)
+            .to receive(:safe_load_file)
                   .with(package_todo_file)
                   .and_return(
                     '.' => {

--- a/spec/lib/graphwerk/package_todo_loader_spec.rb
+++ b/spec/lib/graphwerk/package_todo_loader_spec.rb
@@ -53,6 +53,15 @@ module Graphwerk
 
         it { is_expected.to contain_exactly('.') }
       end
+
+    end
+
+    describe '#load with a real YAML fixture file' do
+      let(:root_path) { Pathname.new(File.expand_path('../../support/fixtures', __dir__)) }
+
+      it 'parses the file with safe_load_file and returns the keys' do
+        expect(service.load).to contain_exactly('.', 'components/shipping')
+      end
     end
   end
 end

--- a/spec/support/fixtures/components/admin/deprecated_references.yml
+++ b/spec/support/fixtures/components/admin/deprecated_references.yml
@@ -1,0 +1,13 @@
+---
+".":
+  "::Order":
+    violations:
+    - dependency
+    files:
+    - components/admin/interfaces/gateway.rb
+"components/shipping":
+  "::ShippingLabel":
+    violations:
+    - privacy
+    files:
+    - components/admin/views/label.rb

--- a/spec/support/fixtures/components/admin/package_todo.yml
+++ b/spec/support/fixtures/components/admin/package_todo.yml
@@ -1,0 +1,13 @@
+---
+".":
+  "::Order":
+    violations:
+    - dependency
+    files:
+    - components/admin/interfaces/gateway.rb
+"components/shipping":
+  "::ShippingLabel":
+    violations:
+    - privacy
+    files:
+    - components/admin/views/label.rb


### PR DESCRIPTION
## Summary
This PR replaces unsafe `YAML.load_file` calls with `YAML.safe_load_file` to prevent potential code execution vulnerabilities when loading YAML files.

## Changes
- Updated `DeprecatedReferencesLoader#load` to use `YAML.safe_load_file` instead of `YAML.load_file`
- Updated `PackageTodoLoader#load` to use `YAML.safe_load_file` instead of `YAML.load_file`

## Details
`YAML.load_file` can deserialize arbitrary Ruby objects, which poses a security risk if the YAML files come from untrusted sources or could be modified by attackers. `YAML.safe_load_file` only deserializes basic data types (strings, numbers, arrays, hashes, etc.) and prevents instantiation of arbitrary Ruby classes, making it the safer choice for loading configuration and data files.

Both loaders already handle the case where the file doesn't exist or returns nil, so this change is a drop-in replacement with no functional impact on the existing behavior.

https://claude.ai/code/session_01L3z7pmGpriqtiQzfnTAgZq