### PR TITLE
Update homepage URL in gemspec

### DIFF
--- a/graphwerk.gemspec
+++ b/graphwerk.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['samuel.giles@bellroy.com']
 
   spec.summary       = "Visualise dependencies between your application and it's Packwerk packages using Graphviz."
-  spec.homepage      = 'https://github.com/tricycle/graphwerk'
+  spec.homepage      = 'https://github.com/samuelgiles/graphwerk'
   spec.license       = 'MIT'
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
## Summary
Updates the homepage URL in the gemspec to reflect the correct repository location.

## Changes
- Changed homepage URL from `https://github.com/tricycle/graphwerk` to `https://github.com/samuelgiles/graphwerk`

## Details
This change updates the gem's metadata to point to the correct GitHub repository owner, ensuring users can easily find the project's source code and documentation.

https://claude.ai/code/session_01WbQ6fim8tFo6WfBELPYHsd