### PR TITLE
Add nil-guards to deprecated_references and package_todo edge drawing

### DIFF
--- a/lib/graphwerk/builders/graph.rb
+++ b/lib/graphwerk/builders/graph.rb
@@ -121,6 +121,8 @@ module Graphwerk
       sig { params(package: Presenters::Package).void }
       def draw_deprecated_references(package)
         package.deprecated_references.each do |reference|
+          next unless @nodes[reference]
+
           @graph.add_edges(
             @nodes[package.name],
             @nodes[reference],
@@ -132,6 +134,8 @@ module Graphwerk
       sig { params(package: Presenters::Package).void }
       def draw_package_todos(package)
         package.package_todos.each do |todo|
+          next unless @nodes[todo]
+
           @graph.add_edges(
             @nodes[package.name],
             @nodes[todo],

--- a/spec/lib/graphwerk/builders/graph_spec.rb
+++ b/spec/lib/graphwerk/builders/graph_spec.rb
@@ -128,6 +128,42 @@ module Graphwerk
           end
         end
 
+        context 'when a deprecated reference points to a package not in the graph' do
+          let(:deprecated_references_loader_for_images) do
+            instance_double(DeprecatedReferencesLoader, load: ['.', 'components/unknown'])
+          end
+
+          specify do
+            expect { diagram }.not_to raise_error
+          end
+
+          it 'skips the edge for the missing package' do
+            expect(diagram).not_to include('unknown')
+          end
+
+          it 'still draws edges for known packages' do
+            expect(diagram).to include('images -> Application [color = "red"]')
+          end
+        end
+
+        context 'when a package todo points to a package not in the graph' do
+          let(:package_todo_loader_for_frontend) do
+            instance_double(PackageTodoLoader, load: ['components/storage_providers/s3', 'components/nonexistent'])
+          end
+
+          specify do
+            expect { diagram }.not_to raise_error
+          end
+
+          it 'skips the edge for the missing package' do
+            expect(diagram).not_to include('nonexistent')
+          end
+
+          it 'still draws edges for known packages' do
+            expect(diagram).to include('frontend -> "storage_providers/s3" [color = "red"]')
+          end
+        end
+
         context 'when hiding todos' do
           let(:builder) { described_class.new(package_set, options: { hide_todo: true }) }
 


### PR DESCRIPTION
## Summary
- `draw_deprecated_references` and `draw_package_todos` now skip edges when the referenced package isn't present in the graph
- Matches the existing nil-guard pattern in `draw_dependencies`, which already calls `abort` / guards against missing nodes

## Test plan
- [x] Full spec suite passes (16 examples, 0 failures)

https://claude.ai/code/session_01WbQ6fim8tFo6WfBELPYHsd