### PR TITLE
Replace ENV['PWD'] with Dir.pwd for root path default

### DIFF
--- a/lib/graphwerk/builders/graph.rb
+++ b/lib/graphwerk/builders/graph.rb
@@ -48,7 +48,7 @@ module Graphwerk
       }, OptionsShape)
 
       sig { params(package_set: Packwerk::PackageSet, options: T::Hash[Symbol, Object], root_path: Pathname).void }
-      def initialize(package_set, options: {}, root_path: Pathname.new(ENV['PWD']))
+      def initialize(package_set, options: {}, root_path: Pathname.new(Dir.pwd))
         @package_set = package_set
         @options = T.let(DEFAULT_OPTIONS.deep_merge(options), OptionsShape)
         @root_path = root_path


### PR DESCRIPTION
## Summary
Updated the default `root_path` parameter in the `Graph` initializer to use `Dir.pwd` instead of `ENV['PWD']`.

## Changes
- Replaced `Pathname.new(ENV['PWD'])` with `Pathname.new(Dir.pwd)` in the `Graph#initialize` method

## Details
`Dir.pwd` is the more reliable and idiomatic Ruby approach for getting the current working directory. Unlike `ENV['PWD']`, which depends on the environment variable being set and can become stale in certain scenarios (e.g., after directory changes in the same process), `Dir.pwd` always returns the actual current working directory. This change improves robustness and reduces potential issues related to environment variable state.

https://claude.ai/code/session_01JC5zh7G3EbjATgooqBfiBw